### PR TITLE
Improved support for nested babelrc files

### DIFF
--- a/docs/rules/use-alias.md
+++ b/docs/rules/use-alias.md
@@ -56,6 +56,7 @@ const fetchData = await import('actions/fetchData')
 ...
 "module-resolver/use-alias": [<enabled>, {
   "ignoreDepth": <number>,
+  "projectRoot": <string>,
   "extensions": <array>
 }]
 ...
@@ -70,6 +71,18 @@ With the below `ignoreDepth` set, all of the above patterns causing warnings wou
 ```json
 "module-resolver/use-alias": ["error", {
   "ignoreDepth": 2
+}]
+```
+
+### `projectRoot`
+
+String representing a path from your workspace directory to your projectRoot directory where the `.babelrc` and `.eslintrc` files exist. By default this option is unused.
+
+This is useful in a monorepo or projects that have these files nested in a subdirectory _(e.g. `<rootDir>/package/project/.eslintrc`)_.
+
+```json
+"module-resolver/use-alias": ["error", {
+  "projectRoot": "/package/project"
 }]
 ```
 

--- a/lib/helpers/build-ignore-prefix.js
+++ b/lib/helpers/build-ignore-prefix.js
@@ -1,0 +1,11 @@
+function buildIgnorePrefix(ignoreDepth) {
+  if (!ignoreDepth || isNaN(ignoreDepth)) {
+    return null
+  }
+
+  return Array(ignoreDepth)
+    .fill('../')
+    .join('')
+}
+
+module.exports = buildIgnorePrefix

--- a/lib/helpers/find-project-root.js
+++ b/lib/helpers/find-project-root.js
@@ -1,0 +1,31 @@
+const path = require('path')
+
+const isString = str => typeof str === 'string'
+
+function findProjectRoot(filePath = '', projectRoot = '') {
+  if (
+    !filePath ||
+    !isString(filePath) ||
+    !projectRoot ||
+    !isString(projectRoot)
+  ) {
+    return null
+  }
+
+  const normalizedFilePath = path.normalize(filePath)
+  const normalizedProjectRoot = path
+    .normalize(projectRoot)
+    // remove leading ["../", "./". "/"] or multiples of (e.g. "../../")
+    .replace(/^(\.\.\/)+|^(\.\.\\)+|^(\.\/)+|^(\.\\)+|^(\/)+|^(\\)+/, '')
+    // remove trailing slash(s)
+    .replace(/(\/)+$|(\\)+$/, '')
+
+  if (normalizedFilePath.includes(normalizedProjectRoot)) {
+    const [workspaceRoot] = normalizedFilePath.split(normalizedProjectRoot)
+    return `${workspaceRoot}${normalizedProjectRoot}`
+  }
+
+  return null
+}
+
+module.exports = findProjectRoot

--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -2,15 +2,17 @@ const findBabelConfig = require('find-babel-config')
 const path = require('path')
 const fs = require('fs')
 
+const buildIgnorePrefix = require('../helpers/build-ignore-prefix')
 const checkIgnoreDepth = require('../helpers/check-ignore-depth')
+const findProjectRoot = require('../helpers/find-project-root')
 const getProperties = require('../helpers/get-properties')
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 const values = Object.values || (obj => Object.keys(obj).map(e => obj[e]))
-const checkPath = (path, ext) => fs.existsSync(`${path}${ext}`) || fs.existsSync(`${path}/index${ext}`)
+const checkPath = (path, ext) =>
+  fs.existsSync(`${path}${ext}`) || fs.existsSync(`${path}/index${ext}`)
 
 module.exports = {
   meta: {
@@ -20,66 +22,99 @@ module.exports = {
       recommended: false,
     },
     fixable: null, // or "code" or "whitespace"
-    schema: [{
-      type: 'object',
-      properties: {
-        ignoreDepth: {
-          type: 'number',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignoreDepth: {
+            type: 'number',
+          },
+          projectRoot: {
+            type: 'string',
+          },
+          extensions: {
+            type: 'array',
+            uniqueItems: true,
+            items: {
+              type: 'string',
+              enum: ['.ts', '.tsx', '.jsx'],
+            },
+          },
         },
-        extensions: {
-          type: "array",
-          uniqueItems: true,
-          items: {
-            type: "string",
-            enum: ['.ts', '.tsx', '.jsx']
-          }
-        },
+        additionalProperties: false,
       },
-      additionalProperties: false,
-    }],
+    ],
   },
 
   create: function(context) {
-    const { config } = findBabelConfig.sync('.')
-    const { options } = context
-    // try/catch
-    // handle name collision with package.json
+    const filename = context.getFilename()
+    const filePath = path.dirname(filename)
 
-    const validPluginNames = new Set(['babel-plugin-module-resolver', 'module-resolver'])
+    // Plugin options.
+    const options = getProperties(context.options)
+    const ignorePrefix = buildIgnorePrefix(options.ignoreDepth)
+    const projectRootAbsolutePath = findProjectRoot(
+      filePath,
+      options.projectRoot,
+    )
 
-    const [ moduleResolver ] = config.plugins.filter(plugins => {
-      if (Array.isArray(plugins) && validPluginNames.has(plugins[0])) {
-        return plugins
+    // Find alias via babel-plugin-module-resolver config.
+    let alias = {}
+    const babelDir = projectRootAbsolutePath || '.'
+    const { config } = findBabelConfig.sync(babelDir)
+    try {
+      const validPluginNames = new Set([
+        'babel-plugin-module-resolver',
+        'module-resolver',
+      ])
+      const [moduleResolver] = config.plugins.filter(plugins => {
+        if (Array.isArray(plugins) && validPluginNames.has(plugins[0])) {
+          return plugins
+        }
+      })
+      alias = moduleResolver[1].alias
+    } catch (error) {
+      const message = 'Unable to find config for babel-plugin-module-resolver'
+      return {
+        ImportDeclaration(node) {
+          context.report({ node, message, loc: node.source.loc })
+        },
+        CallExpression(node) {
+          context.report({ node, message, loc: node.arguments[0].loc })
+        },
       }
-    })
+    }
 
-    const { alias = {}, root } = moduleResolver[1]
-
-    const normalizedAliasArray = values(alias).map(a => path.join(process.cwd(), a))
+    // Build array of alias paths.
+    const cwd = projectRootAbsolutePath || process.cwd()
+    const aliasPaths = values(alias).map(a => path.join(cwd, a))
 
     const hasError = val => {
       if (!val) return // template literals will have undefined val
 
-      const { ignoreDepth, extensions } = getProperties(options)
+      const { ignoreDepth, projectRoot, extensions } = options
 
-      if (ignoreDepth) {
-        const ignorePrefix = Array(ignoreDepth).fill('../').join('')
+      // Ignore if directory depth matches options.
+      if (ignoreDepth && checkIgnoreDepth({ ignorePrefix, path: val })) return
 
-        if (checkIgnoreDepth({ ignorePrefix, path: val })) return
+      // Error if projectRoot option specified but cannot be resolved.
+      if (projectRoot && !projectRootAbsolutePath) {
+        return true
       }
 
-      const filename = context.getFilename()
-      const filePath = path.dirname(filename)
       const resolvedPath = path.resolve(filePath, val)
       const resolvedExt = path.extname(val) ? '' : '.js'
 
       let pathExists = checkPath(resolvedPath, resolvedExt)
 
       if (extensions && !pathExists) {
-        pathExists = extensions.filter(ext => checkPath(resolvedPath, ext)).length
+        pathExists = extensions.filter(ext => checkPath(resolvedPath, ext))
+          .length
       }
 
-      const isAliased = normalizedAliasArray.some(v => resolvedPath.includes(v))
+      const isAliased = aliasPaths.some(aliasPath =>
+        resolvedPath.includes(aliasPath),
+      )
       return isAliased && pathExists && val.match(/\.\.\//) // matches, exists, and starts with ../
     }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "COLLECT_COVERAGE=true jest",
+    "test:coverage": "jest --coverage",
     "prebuild": "yarn clean",
     "build": "babel lib --out-dir dist",
     "build:watch": "yarn build --watch",

--- a/tests/__mocks__/find-babel-config.js
+++ b/tests/__mocks__/find-babel-config.js
@@ -1,7 +1,0 @@
-const findBabelConfig = jest.genMockFromModule('find-babel-config')
-
-findBabelConfig.sync = () => ({
-  config: require('../babelrc'),
-})
-
-module.exports = findBabelConfig

--- a/tests/helpers/build-ignore-prefix.spec.js
+++ b/tests/helpers/build-ignore-prefix.spec.js
@@ -1,0 +1,27 @@
+const buildIgnorePrefix = require('../../lib/helpers/build-ignore-prefix')
+
+describe('buildIgnorePrefix', () => {
+  it('is a function', () => {
+    expect(buildIgnorePrefix).toBeInstanceOf(Function)
+  })
+
+  it('returns null when no arguments are passed', () => {
+    const prefix = buildIgnorePrefix()
+    expect(prefix).toBe(null)
+  })
+
+  it('returns null when invalid arguments are passed', () => {
+    const prefix = buildIgnorePrefix('invalid')
+    expect(prefix).toBe(null)
+  })
+
+  it('returns ../ for an ignoreDepth of 1', () => {
+    const prefix = buildIgnorePrefix(1)
+    expect(prefix).toBe("../")
+  })
+
+  it('returns ../../ for an ignoreDepth of 2', () => {
+    const prefix = buildIgnorePrefix(2)
+    expect(prefix).toBe("../../")
+  })
+})

--- a/tests/helpers/find-project-root.spec.js
+++ b/tests/helpers/find-project-root.spec.js
@@ -1,0 +1,55 @@
+const path = require('path')
+const findProjectRoot = require('../../lib/helpers/find-project-root')
+
+describe('findProjectRoot', () => {
+  const filePath = path.normalize('/dev/monorepo/project/one/some/dir')
+  const projectRootAbsolutePath = path.normalize('/dev/monorepo/project/one')
+
+  it('is a function', () => {
+    expect(findProjectRoot).toBeInstanceOf(Function)
+  })
+
+  it('returns null when no arguments are passed', () => {
+    const root = findProjectRoot()
+    expect(root).toBe(null)
+  })
+
+  it('returns null when invalid arguments are passed', () => {
+    const invalid1 = findProjectRoot(95)
+    const invalid2 = findProjectRoot(filePath, 8)
+    const invalid3 = findProjectRoot(undefined, 8)
+    expect(invalid1).toBe(null)
+    expect(invalid2).toBe(null)
+    expect(invalid3).toBe(null)
+  })
+
+  it('returns null when projectRoot option does NOT exist', () => {
+    const prefix = findProjectRoot(filePath, 'cannot/be/found')
+    expect(prefix).toBe(null)
+  })
+
+  it('returns absolute path for a nested project root', () => {
+    const prefix = findProjectRoot(filePath, 'project/one')
+    expect(prefix).toBe(projectRootAbsolutePath)
+  })
+
+  it('ignores leading slash on projectRoot option', () => {
+    const prefix = findProjectRoot(filePath, '///project/one')
+    expect(prefix).toBe(projectRootAbsolutePath)
+  })
+
+  it('ignores leading ./ on projectRoot option', () => {
+    const prefix = findProjectRoot(filePath, './././project/one')
+    expect(prefix).toBe(projectRootAbsolutePath)
+  })
+
+  it('ignores leading ../ on projectRoot option', () => {
+    const prefix = findProjectRoot(filePath, '../../project/one')
+    expect(prefix).toBe(projectRootAbsolutePath)
+  })
+
+  it('ignores trailing slash on projectRoot option', () => {
+    const prefix = findProjectRoot(filePath, 'project/one/////')
+    expect(prefix).toBe(projectRootAbsolutePath)
+  })
+})

--- a/tests/lib/rules/use-alias.spec.js
+++ b/tests/lib/rules/use-alias.spec.js
@@ -1,8 +1,15 @@
-const rule = require('../../../lib/rules/use-alias')
+const fs = require('fs')
+const findBabelConfig = require('find-babel-config')
 const { RuleTester } = require('eslint')
 
-const fs = require('fs')
+const rule = require('../../../lib/rules/use-alias')
+const babelConfig = require('../../babelrc')
 
+jest.mock("find-babel-config", () => ({
+  sync: jest.fn(() => ({ config: ({}) })),
+}));
+
+const projectRoot = '/project'
 let existsSyncSpy
 let cwdSpy
 
@@ -15,7 +22,7 @@ beforeEach(() => {
       return true
     }
   )
-  cwdSpy = jest.spyOn(process, 'cwd').mockImplementation(() => '/project')
+  cwdSpy = jest.spyOn(process, 'cwd').mockImplementation(() => projectRoot)
 })
 
 afterEach(() => {
@@ -28,88 +35,130 @@ const createInvalid = (...args) => {
   let type
   let filename
   let options = []
-  let defaultFilename = '/project/src/account.js'
+  let errorMessage
+  
+  const defaultFilename = `${projectRoot}/src/account.js`
+  const defaultErrorMessage = 'Do not use relative path for aliased modules'
 
   if (args.length === 1) {
     const [ obj ] = args
-    ;({ code, type, filename, options = [] } = obj)
+    ;({ code, type, filename, options = [], errorMessage } = obj)
   } else {
-    [ code, type, filename ] = args
+    [ code, type, filename, errorMessage ] = args
   }
-
-  filename = filename || defaultFilename
 
   return {
     code,
-    filename,
-    options,
+    filename: filename || defaultFilename,
+    options: options || [],
     errors: [
       {
-        message: 'Do not use relative path for aliased modules',
+        message: errorMessage || defaultErrorMessage,
         type,
       },
     ],
   }
 }
 
-const ruleTester = new RuleTester({ parser: 'babel-eslint' })
-ruleTester.run('module-resolver', rule, {
-  valid: [
-    "require('actions/api')",
-    "require('reducers/api')",
-    "require('ClientMain/api')",
-    "const { api } = require('actions/api')",
-    "const { api } = require('reducers/api')",
-    "import('actions/api')",
-    "import('reducers/api')",
-    "import(`${buildPath}/dist`)",
-    "import { api } from 'reducers/api'",
-    "import { api } from 'reducers/api'",
-    "const { api } = dynamic(import('actions/api'))",
-    "const { api } = dynamic(import('reducers/api'))",
-    "const { server } = require(`${buildPath}/dist`)",
-    "const { api } = require('./actions/api')",
-    "const { api } = require('./reducers/api')",
-    "import { api } from './reducers/api'",
-    "import { api } from './reducers/api'",
-    "const { api } = dynamic(import('./src/client/main'))",
-    createInvalid({
-      code: "const { api } = dynamic(import('../reducers/api'))",
-      type: "CallExpression",
-      options: [{ ignoreDepth: 1 }],
-    }),
-    createInvalid({
-      code: "import ClientMain from '../../../client/main/components/App'",
-      type: "ImportDeclaration",
-      filename: "/project/src/client/main/utils/index.js",
-      options: [{ ignoreDepth: 3 }],
-    }),
-  ],
+describe('with babel config', () => {
+  beforeEach(() => {
+    findBabelConfig.sync.mockImplementation(() => ({ config: babelConfig }))
+  })
 
-  invalid: [
-    createInvalid("require('../actions/api')", "CallExpression"),
-    createInvalid("require('../reducers/api')", "CallExpression"),
-    createInvalid("import('../../actions/api')", "CallExpression", "/project/src/client/index.js"),
-    createInvalid("import('../../reducers/api')", "CallExpression", "/project/src/client/index.js"),
-    createInvalid("const { api } = dynamic(import('../actions/api'))", "CallExpression"),
-    createInvalid("import ClientMain from '../../../client/main/components/App'", "ImportDeclaration", "/project/src/client/main/utils/index.js"),
-    createInvalid("const { api } = dynamic(import('../reducers/api'))", "CallExpression"),
-    createInvalid({
-      code: "const { api } = dynamic(import('../reducers/api'))",
-      type: "CallExpression",
-      options: [{ ignoreDepth: 2 }],
-    }),
-    createInvalid({
-      code: "import ClientMain from '../../../client/main/components/App'",
-      type: "ImportDeclaration",
-      filename: "/project/src/client/main/utils/index.js",
-      options: [{ ignoreDepth: 1 }],
-    }),
-    createInvalid({
-      code: "import { parseResponse } from '../../../../lib/parsers'",
-      type: "ImportDeclaration",
-      filename: "/project/src/client/main/utils/index.js",
-      options: [{ extensions: ['.ts'] }],
-    }),
-  ],
+  const ruleTester = new RuleTester({ parser: 'babel-eslint' })
+  ruleTester.run('module-resolver', rule, {
+    valid: [
+      "require('actions/api')",
+      "require('reducers/api')",
+      "require('ClientMain/api')",
+      "const { api } = require('actions/api')",
+      "const { api } = require('reducers/api')",
+      "import('actions/api')",
+      "import('reducers/api')",
+      "import(`${buildPath}/dist`)",
+      "import { api } from 'actions/api'",
+      "import { api } from 'reducers/api'",
+      "const { api } = dynamic(import('actions/api'))",
+      "const { api } = dynamic(import('reducers/api'))",
+      "const { server } = require(`${buildPath}/dist`)",
+      "const { api } = require('./actions/api')",
+      "const { api } = require('./reducers/api')",
+      "import { api } from './reducers/api'",
+      "import { api } from './reducers/api'",
+      "const { api } = dynamic(import('./src/client/main'))",
+      createInvalid({
+        code: "const { api } = dynamic(import('../reducers/api'))",
+        type: "CallExpression",
+        options: [{ ignoreDepth: 1 }],
+      }),
+      createInvalid({
+        code: "import ClientMain from '../../../client/main/components/App'",
+        type: "ImportDeclaration",
+        filename: `${projectRoot}/src/client/main/utils/index.js`,
+        options: [{ ignoreDepth: 3 }],
+      }),
+      createInvalid({
+        code: "import('actions/api')",
+        type: "ImportDeclaration",
+        filename: `${projectRoot}/package/one/src/client/main/utils/index.js`,
+        options: [{ projectRoot: "package/one" }],
+      }),
+    ],
+  
+    invalid: [
+      createInvalid("require('../actions/api')", "CallExpression"),
+      createInvalid("require('../reducers/api')", "CallExpression"),
+      createInvalid("import('../../actions/api')", "CallExpression", `${projectRoot}/src/client/index.js`),
+      createInvalid("import('../../reducers/api')", "CallExpression", `${projectRoot}/src/client/index.js`),
+      createInvalid("const { api } = dynamic(import('../actions/api'))", "CallExpression"),
+      createInvalid("import ClientMain from '../../../client/main/components/App'", "ImportDeclaration", `${projectRoot}/src/client/main/utils/index.js`),
+      createInvalid("const { api } = dynamic(import('../reducers/api'))", "CallExpression"),
+      createInvalid({
+        code: "const { api } = dynamic(import('../reducers/api'))",
+        type: "CallExpression",
+        options: [{ ignoreDepth: 2 }],
+      }),
+      createInvalid({
+        code: "import ClientMain from '../../../client/main/components/App'",
+        type: "ImportDeclaration",
+        filename: `${projectRoot}/src/client/main/utils/index.js`,
+        options: [{ ignoreDepth: 1 }],
+      }),
+      createInvalid({
+        code: "import('actions/api')",
+        type: "CallExpression",
+        filename: `${projectRoot}/package/one/src/client/main/utils/index.js`,
+        options: [{ projectRoot: "invalid/project" }],
+      }),
+      createInvalid({
+        code: "import { parseResponse } from '../../../../lib/parsers'",
+        type: "ImportDeclaration",
+        filename: `${projectRoot}/src/client/main/utils/index.js`,
+        options: [{ extensions: ['.ts'] }],
+      }),
+    ],
+  })
+})
+
+describe('without babel config', () => {
+  beforeEach(() => {
+    findBabelConfig.sync.mockImplementation(() => ({ config: {} }))
+  })
+
+  const ruleTester = new RuleTester({ parser: 'babel-eslint' })
+  ruleTester.run('module-resolver', rule, {
+    valid: [],
+    invalid: [
+      createInvalid({
+        code: "require('actions/api')",
+        type: "CallExpression",
+        errorMessage: 'Unable to find config for babel-plugin-module-resolver'
+      }),
+      createInvalid({
+        code: "import { api } from './reducers/api'",
+        type: "ImportDeclaration",
+        errorMessage: 'Unable to find config for babel-plugin-module-resolver'
+      }),
+    ],
+  })
 })


### PR DESCRIPTION
Fixes #15 

- Improve support for projects that have eslintrc and babelrc in nested in directories outside of project root. This mostly assists IDE's to find the correct config so they can show ESLint errors.
- Update README with some instructions to help users of VS Code + ESLint plugin with nested config files.
- Update test coverage script to work correctly with newer version of jest.