### PR TITLE
Add support for allowDepthMoreOrLessThanEquality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,23 @@ Add `module-resolver` to the plugins section of your `.eslintrc` configuration f
 
 ```json
 {
-    "plugins": [
-        "module-resolver"
-    ]
+  "plugins": ["module-resolver"]
 }
 ```
 
-Then configure the rules you want to use under the rules section.
+Then configure the rules you want to use under the rules section of `.eslintrc`.
 
 ```json
 {
-    "rules": {
-        "module-resolver/use-alias": 2
-    }
+  "rules": {
+    "module-resolver/use-alias": 2
+  }
 }
 ```
 
 ## Supported Rules
 
-* [module-resolver/use-alias](docs/rules/use-alias.md) - Warn when aliased paths are using relative paths
+- [module-resolver/use-alias](docs/rules/use-alias.md) - Warn when aliased paths are using relative paths
 
 # License
 

--- a/docs/rules/use-alias.md
+++ b/docs/rules/use-alias.md
@@ -57,20 +57,33 @@ const fetchData = await import('actions/fetchData')
 "module-resolver/use-alias": [<enabled>, {
   "ignoreDepth": <number>,
   "projectRoot": <string>,
-  "extensions": <array>
+  "extensions": <array>,
+  "allowDepthMoreOrLessThanEquality": <boolean>
 }]
 ...
 ```
 
 ### `ignoreDepth`
 
-Number representing a depth that can be ignored for aliased imports. By default this option is unused.
+Number representing a depth that can be ignored for aliased imports. Performs strict equality by default. If you want to allow depth of exact or lesser number, check `allowDepthMoreOrLessThanEquality`. By default this option is unused.
 
 With the below `ignoreDepth` set, all of the above patterns causing warnings would no longer. The other cases would continue being valid as well.
 
 ```json
 "module-resolver/use-alias": ["error", {
   "ignoreDepth": 2
+}]
+```
+
+### `allowDepthMoreOrLessThanEquality`
+
+Boolean `allowDepthMoreOrLessThanEquality` sets the equality rule for `ignoreDepth`. By default this option is unused (strict equality is performed).
+
+With the below `allowDepthMoreOrLessThanEquality` set to `true`, all the pattern with depth equal or less than the `ignoreDepth` will be allowed.
+
+```json
+"module-resolver/use-alias": ["error", {
+  "allowDepthMoreOrLessThanEquality": false
 }]
 ```
 

--- a/lib/helpers/check-ignore-depth.js
+++ b/lib/helpers/check-ignore-depth.js
@@ -1,13 +1,19 @@
 const path = require('path')
 const isString = str => typeof str === 'string'
 
-const checkIgnoreDepth = ({ ignoreDepth, path: pathInput } = {}) => {
+const checkIgnoreDepth = ({
+  ignoreDepth,
+  path: pathInput,
+  allowDepthMoreOrLessThanEquality,
+} = {}) => {
   if (!ignoreDepth || !isString(pathInput)) return false
 
   const pathArray = path.normalize(pathInput).split(path.sep)
   const doubleDotsNumber = pathArray.findIndex(pathPart => pathPart !== '..')
 
-  return ignoreDepth === doubleDotsNumber
+  return allowDepthMoreOrLessThanEquality
+    ? ignoreDepth >= doubleDotsNumber
+    : ignoreDepth === doubleDotsNumber
 }
 
 module.exports = checkIgnoreDepth

--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -23,7 +23,11 @@ module.exports = {
         type: 'object',
         properties: {
           ignoreDepth: {
-            type: 'number',
+            type: 'integer',
+            minimum: 0,
+          },
+          allowDepthMoreOrLessThanEquality: {
+            type: 'boolean',
           },
           projectRoot: {
             type: 'string',
@@ -81,10 +85,10 @@ module.exports = {
     const hasError = val => {
       if (!val) return // template literals will have undefined val
 
-      const { ignoreDepth, projectRoot, extensions } = options
+      const { ignoreDepth, projectRoot, extensions, allowDepthMoreOrLessThanEquality } = options
 
       // Ignore if directory depth matches options.
-      if (checkIgnoreDepth({ ignoreDepth, path: val })) return
+      if (checkIgnoreDepth({ ignoreDepth, path: val, allowDepthMoreOrLessThanEquality })) return
 
       // Error if projectRoot option specified but cannot be resolved.
       if (projectRoot && !projectRootAbsolutePath) {

--- a/tests/helpers/check-ignore-depth.spec.js
+++ b/tests/helpers/check-ignore-depth.spec.js
@@ -70,4 +70,35 @@ describe('checkIgnoreDepth', () => {
     expect(result2).toBe(false)
     expect(result3).toBe(false)
   })
+
+  it('returns correct boolean if the path returns a value less than or equal to ignoreDepth', () => {
+    const result1 = checkIgnoreDepth({
+      ignoreDepth: 1,
+      path: '../../routes/index.js',
+      allowDepthMoreOrLessThanEquality: true,
+    })
+
+    const result2 = checkIgnoreDepth({
+      ignoreDepth: 2,
+      path: '../../../routes/index.js',
+      allowDepthMoreOrLessThanEquality: true,
+    })
+
+    const result3 = checkIgnoreDepth({
+      ignoreDepth: 3,
+      path: '../routes/index.js',
+      allowDepthMoreOrLessThanEquality: true,
+    })
+
+    const result4 = checkIgnoreDepth({
+      ignoreDepth: 2,
+      path: '../../routes/index.js',
+      allowDepthMoreOrLessThanEquality: true,
+    })
+
+    expect(result1).toBe(false)
+    expect(result2).toBe(false)
+    expect(result3).toBe(true)
+    expect(result4).toBe(true)
+  })
 })


### PR DESCRIPTION
Add an option for non strict equality, so rule could ignore depths of value equal or less than `ignoreDepth`. Also changed `ignoreDepth` schema to `integer` from `number` with a minimum of 0 (seems like fractions and negatives should be invalid options). Option name is `allowDepthMoreOrLessThanEquality` is bulky, maybe you have a better idea, for which it would make sense to have `false` as a default value, so it wouldn't break previous configs.