### PR TITLE
Use babel's loadPartialConfig to get root babel config

### DIFF
--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -1,4 +1,4 @@
-const findBabelConfig = require('find-babel-config')
+const babel = require('@babel/core')
 const path = require('path')
 const fs = require('fs')
 
@@ -56,16 +56,16 @@ module.exports = {
 
     // Find alias via babel-plugin-module-resolver config.
     let alias = {}
-    const babelDir = projectRootAbsolutePath || '.'
-    const { config } = findBabelConfig.sync(babelDir)
+    const partialConfig = babel.loadPartialConfig()
+    const configOptions = partialConfig.options
     try {
       const validPluginNames = new Set(['babel-plugin-module-resolver', 'module-resolver'])
-      const [moduleResolver] = config.plugins.filter((plugins) => {
-        if (Array.isArray(plugins) && validPluginNames.has(plugins[0])) {
-          return plugins
+      const [moduleResolver] = configOptions.plugins.filter(plugin => {
+        if (validPluginNames.has(plugin.file && plugin.file.request)) {
+          return plugin
         }
       })
-      alias = moduleResolver[1].alias || {}
+      alias = moduleResolver.options.alias || {}
     } catch (error) {
       const message = 'Unable to find config for babel-plugin-module-resolver'
       return {

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
       "git add"
     ]
   },
-  "dependencies": {
-    "find-babel-config": "^1.2.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",

--- a/tests/babelrc.js
+++ b/tests/babelrc.js
@@ -1,9 +1,11 @@
 module.exports = {
-  presets: ['env'],
+  presets: [],
   plugins: [
-    [
-      'babel-plugin-module-resolver',
-      {
+    {
+      file: {
+        request: 'babel-plugin-module-resolver'
+      },
+      options: {
         root: ['.'],
         alias: {
           actions: './actions',
@@ -11,7 +13,7 @@ module.exports = {
           lib: './lib',
           ClientMain: './src/client/main',
         },
-      },
-    ],
-  ],
+      }
+    }
+  ]
 }

--- a/tests/lib/rules/use-alias.spec.js
+++ b/tests/lib/rules/use-alias.spec.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-template-curly-in-string */
 const fs = require('fs')
-const findBabelConfig = require('find-babel-config')
+const babel = require('@babel/core')
 const { RuleTester } = require('eslint')
 
 const rule = require('../../../lib/rules/use-alias')
 const babelConfig = require('../../babelrc')
 
-jest.mock('find-babel-config', () => ({
-  sync: jest.fn(() => ({ config: {} })),
+jest.mock('@babel/core', () => ({
+  loadPartialConfig: jest.fn(() => ({ options: {} })),
 }))
 
 const projectRoot = '/project'
@@ -51,7 +51,7 @@ const createInvalid = ({
 
 describe('with babel config', () => {
   beforeEach(() => {
-    findBabelConfig.sync.mockImplementation(() => ({ config: babelConfig }))
+    babel.loadPartialConfig.mockImplementation(() => ({ options: babelConfig }))
   })
 
   const ruleTester = new RuleTester({
@@ -166,7 +166,7 @@ describe('with babel config', () => {
 
 describe('without babel config', () => {
   beforeEach(() => {
-    findBabelConfig.sync.mockImplementation(() => ({ config: {} }))
+    babel.loadPartialConfig.mockImplementation(() => ({ options: { plugins: [] } }))
   })
 
   const ruleTester = new RuleTester({

--- a/tests/lib/rules/use-alias.spec.js
+++ b/tests/lib/rules/use-alias.spec.js
@@ -6,9 +6,7 @@ const { RuleTester } = require('eslint')
 const rule = require('../../../lib/rules/use-alias')
 const babelConfig = require('../../babelrc')
 
-jest.mock('@babel/core', () => ({
-  loadPartialConfig: jest.fn(() => ({ options: {} })),
-}))
+jest.mock('@babel/core')
 
 const projectRoot = '/project'
 let existsSyncSpy

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,14 +2609,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-babel-config@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
-  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
-
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"


### PR DESCRIPTION
Fixes #44 

Use loadPartialConfig from the babel API for retrieving the babel config. Prevents errors caused by find-babel-config not passing the api parameter to a babel config function.