### PR TITLE
fix: return normalized paths from fixer on Windows

### DIFF
--- a/lib/helpers/create-fixer.js
+++ b/lib/helpers/create-fixer.js
@@ -19,7 +19,7 @@ const createFixer = (options = {}) => {
 
   const newPath = resolvedPath.replace(aliasPath, '')
 
-  const replacement = path.join(aliasMatch, newPath)
+  const replacement = path.normalize(path.join(aliasMatch, newPath))
 
   return (fixer) => fixer.replaceTextRange([source.range[0] + 1, source.range[1] - 1], replacement)
 }


### PR DESCRIPTION
## Summary

Hi, I just noticed that when eslint fixer is used on Windows, it returns incorrect paths with the wrong slash.
For example, it creates a fix with path `shared\components` instead `shared/components`.

This is due to Windows paths that obviously are defined with a backslash. I added normalize path to fix that problem