### PR TITLE
Allow providing the `alias` map in .eslintrc

### DIFF
--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -40,6 +40,9 @@ module.exports = {
               enum: ['.ts', '.tsx', '.jsx'],
             },
           },
+          alias: {
+            type: 'object',
+          },
         },
         additionalProperties: false,
       },
@@ -54,34 +57,38 @@ module.exports = {
     const options = getProperties(context.options)
     const projectRootAbsolutePath = findProjectRoot(filePath, options.projectRoot)
 
-    // Find alias via babel-plugin-module-resolver config.
-    let alias = {}
-    // Look for default babel.config file
-    let configOptions = babel.loadPartialConfig().options
-    // No plugins found, look for .babelrc config file
-    if (configOptions.plugins.length === 0) {
-      configOptions = babel.loadPartialConfig({
-        configFile: './.babelrc',
-      }).options
-    }
+    // Find alias via babel-plugin-module-resolver config, or use the 
+    // provided alias map.
+    let alias = options.alias;
+    if (!alias) {
+      alias = {}
+      // Look for default babel.config file
+      let configOptions = babel.loadPartialConfig().options
+      // No plugins found, look for .babelrc config file
+      if (configOptions.plugins.length === 0) {
+        configOptions = babel.loadPartialConfig({
+          configFile: './.babelrc',
+        }).options
+      }
 
-    try {
-      const validPluginNames = new Set(['babel-plugin-module-resolver', 'module-resolver'])
-      const [moduleResolver] = configOptions.plugins.filter((plugin) => {
-        if (validPluginNames.has(plugin.file && plugin.file.request)) {
-          return plugin
+      try {
+        const validPluginNames = new Set(['babel-plugin-module-resolver', 'module-resolver'])
+        const [moduleResolver] = configOptions.plugins.filter((plugin) => {
+          if (validPluginNames.has(plugin.file && plugin.file.request)) {
+            return plugin
+          }
+        })
+        alias = moduleResolver.options.alias || {}
+      } catch (error) {
+        const message = 'Unable to find config for babel-plugin-module-resolver'
+        return {
+          ImportDeclaration(node) {
+            context.report({ node, message, loc: node.source.loc })
+          },
+          CallExpression(node) {
+            context.report({ node, message, loc: node.arguments[0].loc })
+          },
         }
-      })
-      alias = moduleResolver.options.alias || {}
-    } catch (error) {
-      const message = 'Unable to find config for babel-plugin-module-resolver'
-      return {
-        ImportDeclaration(node) {
-          context.report({ node, message, loc: node.source.loc })
-        },
-        CallExpression(node) {
-          context.report({ node, message, loc: node.arguments[0].loc })
-        },
       }
     }
 


### PR DESCRIPTION
Not all repos use a `.babelrc`; some may have more in-depth build systems. This change will allow the `module-resolver/use-alias` rule to accept a new `alias` option directly, which takes the same form as the one consumed by the `module-resolver` plugin and avoids needing to find a `.babelrc`.

