### PR TITLE
Fix handling of alias lint rule and fix for shared prefixes

### DIFF
--- a/lib/helpers/create-fixer.js
+++ b/lib/helpers/create-fixer.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const isAliasedPath = require('../helpers/is-alias-path')
+const isAliasPath = require('../helpers/is-alias-path')
 
 const entries = Object.entries || ((obj) => Object.keys(obj).map((key) => [key, obj[key]]))
 
@@ -16,7 +16,7 @@ const createFixer = (options = {}) => {
   const aliasPaths = entries(alias).map(([key, value]) => [key, path.join(cwd, value)])
   const resolvedPath = path.resolve(filePath, source.value)
   const [aliasMatch, aliasPath] = aliasPaths.find(([_, aliasPath]) =>
-    isAliasedPath(resolvedPath, aliasPath)
+    isAliasPath(resolvedPath, aliasPath)
   ) || [];
 
   if (!aliasMatch || !aliasPath) return null

--- a/lib/helpers/create-fixer.js
+++ b/lib/helpers/create-fixer.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const isAliasedPath = require('../helpers/is-aliased-path')
+const isAliasedPath = require('../helpers/is-alias-path')
 
 const entries = Object.entries || ((obj) => Object.keys(obj).map((key) => [key, obj[key]]))
 

--- a/lib/helpers/create-fixer.js
+++ b/lib/helpers/create-fixer.js
@@ -13,7 +13,10 @@ const createFixer = (options = {}) => {
 
   const aliasPaths = entries(alias).map(([key, value]) => [key, path.join(cwd, value)])
   const resolvedPath = path.resolve(filePath, source.value)
-  const [aliasMatch, aliasPath] = aliasPaths.find(([_, aliasPath]) => resolvedPath.includes(aliasPath)) || []
+  const [aliasMatch, aliasPath] = aliasPaths.find(([_, aliasPath]) =>
+    // Prevent replacing the path mid-word
+    resolvedPath.endsWith(aliasPath) || resolvedPath.includes(`${aliasPath}/`)
+  ) || [];
 
   if (!aliasMatch || !aliasPath) return null
 

--- a/lib/helpers/create-fixer.js
+++ b/lib/helpers/create-fixer.js
@@ -1,4 +1,6 @@
 const path = require('path')
+const isAliasedPath = require('../helpers/is-aliased-path')
+
 const entries = Object.entries || ((obj) => Object.keys(obj).map((key) => [key, obj[key]]))
 
 const createFixer = (options = {}) => {
@@ -14,8 +16,7 @@ const createFixer = (options = {}) => {
   const aliasPaths = entries(alias).map(([key, value]) => [key, path.join(cwd, value)])
   const resolvedPath = path.resolve(filePath, source.value)
   const [aliasMatch, aliasPath] = aliasPaths.find(([_, aliasPath]) =>
-    // Prevent replacing the path mid-word
-    resolvedPath.endsWith(aliasPath) || resolvedPath.includes(`${aliasPath}/`)
+    isAliasedPath(resolvedPath, aliasPath)
   ) || [];
 
   if (!aliasMatch || !aliasPath) return null

--- a/lib/helpers/is-alias-path.js
+++ b/lib/helpers/is-alias-path.js
@@ -1,0 +1,7 @@
+function isAliasedPath(resolvedPath, aliasPath) {
+  // Prevent replacing the path mid-word
+  return resolvedPath.endsWith(aliasPath) ||
+    resolvedPath.includes(`${aliasPath}/`);
+}
+
+module.exports = isAliasedPath;

--- a/lib/helpers/is-alias-path.js
+++ b/lib/helpers/is-alias-path.js
@@ -1,7 +1,7 @@
-function isAliasedPath(resolvedPath, aliasPath) {
+function isAliasPath(resolvedPath, aliasPath) {
   // Prevent replacing the path mid-word
   return resolvedPath.endsWith(aliasPath) ||
     resolvedPath.includes(`${aliasPath}/`);
 }
 
-module.exports = isAliasedPath;
+module.exports = isAliasPath;

--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -6,7 +6,7 @@ const checkIgnoreDepth = require('../helpers/check-ignore-depth')
 const findProjectRoot = require('../helpers/find-project-root')
 const getProperties = require('../helpers/get-properties')
 const createFixer = require('../helpers/create-fixer')
-const isAliasedPath = require('../helpers/is-aliased-path')
+const isAliasedPath = require('../helpers/is-alias-path')
 
 const values = Object.values || ((obj) => Object.keys(obj).map((e) => obj[e]))
 const checkPath = (path, ext) => fs.existsSync(`${path}${ext}`) || fs.existsSync(`${path}/index${ext}`)

--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -6,6 +6,7 @@ const checkIgnoreDepth = require('../helpers/check-ignore-depth')
 const findProjectRoot = require('../helpers/find-project-root')
 const getProperties = require('../helpers/get-properties')
 const createFixer = require('../helpers/create-fixer')
+const isAliasedPath = require('../helpers/is-aliased-path')
 
 const values = Object.values || ((obj) => Object.keys(obj).map((e) => obj[e]))
 const checkPath = (path, ext) => fs.existsSync(`${path}${ext}`) || fs.existsSync(`${path}/index${ext}`)
@@ -121,7 +122,9 @@ module.exports = {
         pathExists = extensions.filter((ext) => checkPath(resolvedPath, ext)).length
       }
 
-      const isAliased = aliasPaths.some((aliasPath) => resolvedPath.includes(aliasPath))
+      const isAliased = aliasPaths.some((aliasPath) =>
+        isAliasedPath(resolvedPath, aliasPath)
+      )
 
       const error = isAliased && pathExists && val.match(/\.\.\//) // matches, exists, and starts with ../,
       return error && { suggestFix: true, message: 'Do not use relative path for aliased modules' }

--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -6,7 +6,7 @@ const checkIgnoreDepth = require('../helpers/check-ignore-depth')
 const findProjectRoot = require('../helpers/find-project-root')
 const getProperties = require('../helpers/get-properties')
 const createFixer = require('../helpers/create-fixer')
-const isAliasedPath = require('../helpers/is-alias-path')
+const isAliasPath = require('../helpers/is-alias-path')
 
 const values = Object.values || ((obj) => Object.keys(obj).map((e) => obj[e]))
 const checkPath = (path, ext) => fs.existsSync(`${path}${ext}`) || fs.existsSync(`${path}/index${ext}`)
@@ -123,7 +123,7 @@ module.exports = {
       }
 
       const isAliased = aliasPaths.some((aliasPath) =>
-        isAliasedPath(resolvedPath, aliasPath)
+        isAliasPath(resolvedPath, aliasPath)
       )
 
       const error = isAliased && pathExists && val.match(/\.\.\//) // matches, exists, and starts with ../,

--- a/tests/helpers/is-alias-path.spec.js
+++ b/tests/helpers/is-alias-path.spec.js
@@ -1,0 +1,15 @@
+const isAliasPath = require('../../lib/helpers/is-alias-path');
+
+describe('isAliasPath', () => {
+  it('returns true for aliased module imports', () => {
+    expect(isAliasPath('./src/service', './src/service')).toBe(true);
+  });
+
+  it('returns true for aliased module subpath imports', () => {
+    expect(isAliasPath('./src/service/foo-bar', './src/service')).toBe(true);
+  });
+
+  it('returns false for shared prefix collisions', () => {
+    expect(isAliasPath('./src/services', './src/service')).toBe(false);
+  });
+});

--- a/tests/lib/rules/use-alias.spec.js
+++ b/tests/lib/rules/use-alias.spec.js
@@ -81,6 +81,12 @@ describe('with babel config', () => {
       "import { api } from './reducers/api'",
       "import { api } from './reducers/api'",
       "const { api } = dynamic(import('./src/client/main'))",
+      // Check for shared prefix collision with /lib alias
+      createInvalid({
+        code: "import Maintain from '../../../client/maintain'",
+        type: 'ImportDeclaration',
+        filename: `${projectRoot}/src/client/main/utils/index.js`,
+      }),
       createInvalid({
         code: "const { api } = dynamic(import('../reducers/api'))",
         type: 'ImportExpression',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!

  Learn more about contributing: https://github.com/HeroProtagonist/eslint-plugin-module-resolver/blob/master/CONTRIBUTING.md
-->

## Summary
Before:
The mapping `#service -> src/service` where `src/service` is a directory incorrectly handles a similarly named file like `src/services.js`. The import `src/services` gets rewritten to `#service/s`

After:
The lint-fix and lint rule expect the alias to come either at the end of the path or to end with a /. ie. `src/service` or `src/service/foobar` but NOT `src/services`