### PR TITLE
Support chainedExtensions option ex. style.jss.js

### DIFF
--- a/docs/rules/use-alias.md
+++ b/docs/rules/use-alias.md
@@ -58,6 +58,7 @@ const fetchData = await import('actions/fetchData')
   "ignoreDepth": <number>,
   "projectRoot": <string>,
   "extensions": <array>,
+  "chainedExtensions": <array>,
   "allowDepthMoreOrLessThanEquality": <boolean>,
   "alias": <object>
 }]
@@ -109,6 +110,18 @@ With the below `extensions` array, TypeScript files will also be resolved.
 ```json
 "module-resolver/use-alias": ["error", {
   "extensions": [".ts"]
+}]
+```
+
+### `chainedExtensions`
+
+Array of extensions to check for chaining. For example, React projects use `.jss.js` files to generate CSS styles for components. By default, files with extensions are considered to have only those extensions, while files without default to `.js` (and anything included in `extensions` as described above. This expands the resolution for imports with chained extensions. Any string value is supported.
+
+With the below `chainedExtensions` array, JSS files will also be resolved.
+
+```json
+"module-resolver/use-alias": ["error", {
+  "chainedExtensions": [".jss"]
 }]
 ```
 

--- a/lib/rules/use-alias.js
+++ b/lib/rules/use-alias.js
@@ -41,6 +41,13 @@ module.exports = {
               enum: ['.ts', '.tsx', '.jsx'],
             },
           },
+          chainedExtensions: {
+            type: 'array',
+            uniqueItems: true,
+            items: {
+              type: 'string',
+            },
+          },
           alias: {
             type: 'object',
           },
@@ -101,6 +108,11 @@ module.exports = {
       if (!val) return false // template literals will have undefined val
 
       const { ignoreDepth, projectRoot, extensions, allowDepthMoreOrLessThanEquality } = options
+      let {chainedExtensions = []} = options;
+      // Be forgiving if the config provides "ext" or ".ext"
+      chainedExtensions = chainedExtensions.map(
+        ext => ext.startsWith('.') ? ext : `.${ext}`
+      );
 
       // Ignore if directory depth matches options.
       if (checkIgnoreDepth({ ignoreDepth, path: val, allowDepthMoreOrLessThanEquality })) return false
@@ -114,7 +126,12 @@ module.exports = {
       }
 
       const resolvedPath = path.resolve(filePath, val)
-      const resolvedExt = path.extname(val) ? '' : '.js'
+      const pathExt = path.extname(val);
+      // If no extension is present, or if the extension is explicitly
+      // allowlisted as chainable, resolve the extension to a `.js` file.
+      const resolvedExt = !pathExt || chainedExtensions.includes(pathExt)
+        ? '.js'
+        : ''
 
       let pathExists = checkPath(resolvedPath, resolvedExt)
 

--- a/tests/lib/rules/use-alias.spec.js
+++ b/tests/lib/rules/use-alias.spec.js
@@ -17,6 +17,10 @@ beforeEach(() => {
     if (file.includes('lib/parsers.js') || file.includes('lib/parsers/index.js')) {
       return false
     }
+    // Assume only .js and .ts files exist
+    if (!file.endsWith('.js') && !file.endsWith('.ts')) {
+      return false
+    }
     return true
   })
   cwdSpy = jest.spyOn(process, 'cwd').mockImplementation(() => projectRoot)
@@ -80,6 +84,8 @@ describe('with babel config', () => {
       "const { api } = require('./reducers/api')",
       "import { api } from './reducers/api'",
       "import { api } from './reducers/api'",
+      // Valid unless ".css" is in `chainedExtensions`
+      "import { CSS } from '../../../client/shared.css'",
       "const { api } = dynamic(import('./src/client/main'))",
       // Check for shared prefix collision with /lib alias
       createInvalid({
@@ -163,6 +169,13 @@ describe('with babel config', () => {
         filename: `${projectRoot}/src/client/main/utils/index.js`,
         output: "import { parseResponse } from 'lib/parsers'",
         options: [{ extensions: ['.ts'] }], // check it honor extension option
+      }),
+      createInvalid({
+        code: "import { CSS } from '../../../../lib/shared.css'",
+        type: 'ImportDeclaration',
+        filename: `${projectRoot}/src/client/main/utils/index.js`,
+        output: "import { CSS } from 'lib/shared.css'",
+        options: [{ chainedExtensions: ['.css'] }],
       }),
     ],
   })


### PR DESCRIPTION
Some projects rely on chained file extensions as part of their repo conventions. Two common examples:
1. React-based projects may create `style.jss.js` files, allowing components to import/use styles programatically
2. TypeScript projects (or projects using the Closure Compiler) may include imports of type files such as `foobar.type.js`

Currently, importing a path with any extension causes this plugin to assume it's the only extension, and ignores the declaration. For example, `import FooBarStyles from '../../../foobar.jss';` would pass, while `import FooBarStyles from '../../../foobar.jss.js';` would be invalid.

This PR allows the plugin options to specify a list of chainable extensions. By specifying `"chainedExtensions": [".jss"]`, the plugin will assume any import path ending in `.jss` actually references the file ending in `.jss.js`. PR includes test coverage and documentation updates.